### PR TITLE
Update pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.29</version>
+    <version>3.31</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Updated parent to 3.31 to fix regression when using "mvn hpi:run", discussed at http://jenkins-ci.361315.n4.nabble.com/Re-maven-hpi-plugin-minimumJavaVersion-attribute-must-be-set-tp4961169p4961657.html